### PR TITLE
Update checkpointing.md

### DIFF
--- a/readings/checkpointing.md
+++ b/readings/checkpointing.md
@@ -7,7 +7,7 @@ Checkpointing is a technique to save a program's state so that it can be restart
 
 Checkpointing is not a particularly effective form of fault tolerance. In its basic form, when the system faults the work does not continue, but can be picked up from the last checkpoint which means not all work is lost. However, in a batch-scheduled environment that is common in HPC, checkpointing is still an important form of fault tolerance.
 
-Consider a job that uses 100 nodes (somewhere around 3,000 cores). It is significantly more likely that hardware failure will happen in such a job than in a node which only uses 1 node (24-128 cores). What if hardware failure happens 50 hours into the 100 node job? 50,000 CPU hours would be wasted without checkpointing.
+Consider a job that uses 100 nodes (somewhere around 3,000 cores). It is significantly more likely that hardware failure will happen in such a job than in a node which only uses 1 node (24-128 cores). What if hardware failure happens 50 hours into the 100 node job? 5,000 CPU hours would be wasted without checkpointing.
 
 Some HPC sites have requirements that all code that runs on their system must be able to checkpoint every X hours. Checkpointing can help researchers run programs longer than the maximum walltime set by system administrators. For example, on the Fulton Supercomputing Lab systems, we have walltimes set at 1 day, 3 days, and 7 days. you are partially restricted where you can run based on the time you request for your job. However, no job can run more than 7 days on our system without special permission (which is granted infrequently).
 

--- a/readings/checkpointing.md
+++ b/readings/checkpointing.md
@@ -7,7 +7,7 @@ Checkpointing is a technique to save a program's state so that it can be restart
 
 Checkpointing is not a particularly effective form of fault tolerance. In its basic form, when the system faults the work does not continue, but can be picked up from the last checkpoint which means not all work is lost. However, in a batch-scheduled environment that is common in HPC, checkpointing is still an important form of fault tolerance.
 
-Consider a job that uses 100 nodes (somewhere around 3,000 cores). It is significantly more likely that hardware failure will happen in such a job than in a node which only uses 1 node (24-128 cores). What if hardware failure happens 50 hours into the 100 node job? Between 80,00 and 140,000 CPU hours would be wasted without checkpointing.
+Consider a job that uses 100 nodes (somewhere around 3,000 cores). It is significantly more likely that hardware failure will happen in such a job than in a node which only uses 1 node (24-128 cores). What if hardware failure happens 50 hours into the 100 node job? 50,000 CPU hours would be wasted without checkpointing.
 
 Some HPC sites have requirements that all code that runs on their system must be able to checkpoint every X hours. Checkpointing can help researchers run programs longer than the maximum walltime set by system administrators. For example, on the Fulton Supercomputing Lab systems, we have walltimes set at 1 day, 3 days, and 7 days. you are partially restricted where you can run based on the time you request for your job. However, no job can run more than 7 days on our system without special permission (which is granted infrequently).
 
@@ -19,7 +19,7 @@ Checkpointing can also be helpful when reproducing bugs. If a checkpoint can be 
 
 Consider a program which has an issue 60 minutes into runtime under normal job execution. Now, imagine starting from scratch under a debugger which is slower, often much slower. Instead, start the program without the debugger, save a checkpoint closer to the actual issue, and terminate the program. Then start from the checkpoint under the debugger.
 
-The checkpoint file can also be shared with other developers to observe the bug themselves.
+The checkpoint file can also be shared so other developers can observe the bug themselves.
 
 
 
@@ -27,7 +27,7 @@ The checkpoint file can also be shared with other developers to observe the bug 
 
 There are two forms of checkpointing: internal and external.
 
-**Internal checkpointing** (or application checkpointing) is done by the application itself. It is aware of which state must be preserved and in what format it should be saved in.
+**Internal checkpointing** (or application checkpointing) is done by the application itself. It is aware of which state must be preserved and what format it should be saved in.
 
 **External checkpointing** is done by another application. It is unaware of which state must be preserved and preserves the entire program state. 
 
@@ -47,7 +47,7 @@ External checkpointing is not aware of what data is essential to save and so it 
 - Thread and process state of multi-process and multi-node programs
 - Process ids (PIDs) and relationships between them
 
-There are 3 common tools for doing external checkpoints: [BLCR](LINKhttps://crd.lbl.gov/divisions/amcr/computer-science-amcr/class/research/past-projects/BLCR/) (Berkeley Lab Checkpoint/Restart), [CRIU](LNKhttps://criu.org/Main_Page) (Checkpoint/Restore in Userspace), and [DMTCP](LINKhttp://dmtcp.sourceforge.net/) (Distributed MultiThreaded Checkpointing). BLCR requires Linux Kernel 2.6-3.7. It's historically popular, but its development is in decline and not recommended. CRIU is far more popular with Docker containers than large-scale HPC because it does not support checkpointing MPI programs. Finally, DMTCP is the least widely used solution, but does support MPI programs. This is the currently recommended solution for external checkpointing in HPC.
+There are 3 common tools for doing external checkpoints: [BLCR](https://crd.lbl.gov/divisions/amcr/computer-science-amcr/class/research/past-projects/BLCR/) (Berkeley Lab Checkpoint/Restart), [CRIU](https://criu.org/Main_Page) (Checkpoint/Restore in Userspace), and [DMTCP](https://dmtcp.sourceforge.io/) (Distributed MultiThreaded Checkpointing). BLCR requires Linux Kernel 2.6-3.7. It's historically popular, but its development is in decline, so it is not recommended. CRIU is far more popular with Docker containers than large-scale HPC because it does not support checkpointing MPI programs. Finally, DMTCP is the least widely used solution, but does support MPI programs. This is the currently recommended solution for external checkpointing in HPC.
 
 
 
@@ -74,7 +74,7 @@ dmtcp_command --checkpoint -k
 ./dmtcp_restart_script.sh
 ```
 
-Notice the '`&`' at the end of the launch command–-it's started in the background, then the checkpoint command checkpoints, then kills it (the `-k` flag). A script called `dmtcp_restart_script.sh` will be created by the checkpoint command; it resumes the process from where it was last checkpointed.
+Notice the '`&`' at the end of the launch command—it's started in the background, then the checkpoint command checkpoints, then kills it (the `-k` flag). A script called `dmtcp_restart_script.sh` will be created by the checkpoint command; it resumes the process from where it was last checkpointed.
 
 You can also checkpoint at a fixed interval:
 


### PR DESCRIPTION
Where did "Between 80,00 and 140,000 CPU hours" come from? If it was intentional, maybe some explanation would be nice. Also the en dash followed by hyphen looked pretty weird on the website, and I assume it should have just been an em dash?