### PR TITLE
Update phase5.md Change point total to match Canvas

### DIFF
--- a/project/phase5.md
+++ b/project/phase5.md
@@ -19,7 +19,7 @@ In similar fashion to the [first optimization assignment](phase3.md#submission),
 
 ## Grading
 
-This phase is worth 15 points. The following deductions, up to 15 points total, will apply for a program that doesn't work as laid out by the spec:
+This phase is worth 20 points. The following deductions, up to 20 points total, will apply for a program that doesn't work as laid out by the spec:
 
 | Defect | Deduction |
 | --- | --- |


### PR DESCRIPTION
Currently, Canvas shows all the projects worth 20 points, except MPI which is 30. This reading shows 15 points.

We will grade the current semester with 20 points no matter what.

My guess is that the original author intended to value Phase 5 lower since there are fewer requirements and no new required adjustments. Do we really want to raise it to 20 going forward, or should we keep it at 15 points for future semesters.

Signal decision by merging or closing this PR.