### PR TITLE
Add links to sequence diagrams

### DIFF
--- a/project/phase1.md
+++ b/project/phase1.md
@@ -43,7 +43,9 @@ You can test your implementation in the same way. You'll probably want to [set u
 
 ## C++
 
-If you follow the [example code](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/src/MountainRange.hpp) to create a `WaveOrthotope` class with `solve` and `sim_time` functions and a constructor taking rows, columns, and damping coefficient, your `main` can be very simple:
+We recommend following the pattern demonstratated in the [example code](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/src/MountainRange.hpp). A [simplified sequence diagram](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/docs/MountainRange-simplified-sequence-diagram.md) is available to illustrate the evaluation of the program.
+
+If you follow the pattern of the example code to create a `WaveOrthotope` class with `solve` and `sim_time` functions and a constructor taking rows, columns, and damping coefficient, your `main` can be very simple:
 
 ```c++
 #include <iostream>

--- a/project/phase2.md
+++ b/project/phase2.md
@@ -7,6 +7,8 @@ In this phase you'll make your [wave simulation program](overview.md) more capab
 
 It's a good idea to break your wave orthotope class over multiple classes in such a way that it'll be maximally useful for subsequent phases. I recommend a structure similar to [`mountainsolve` in the example code](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/src/mountainsolve.cpp), although you don't yet need the `#ifdef`s at the top.
 
+A [MountainRange Sequence Diagram](https://github.com/BYUHPC/sci-comp-course-example-cxx/blob/main/docs/MountainRange-sequence-diagram.md) is available that illustrates the evaluation of the example code.
+
 **You can test this and subsequent phases against [wavefiles.tar.gz](wavefiles.tar.gz)**; usage instructions are on the [resources page](../resources.md#the-project).
 
 


### PR DESCRIPTION
This follows up https://github.com/BYUHPC/sci-comp-course-example-cxx/pull/12 to provide links to the diagrams in the course assignment page.